### PR TITLE
reusable card component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import Hero from "./components/Hero";
-import Navbar from "./components/Navbar"
+import Card from "./components/Card";
+import Navbar from "./components/Navbar";
 
 function App() {
   return (
     <div>
       <Navbar />
       <Hero />
+      <Card title="Check out your plan" buttonText="Login" />
     </div>
   );
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,21 @@
+import Button from "./Button";
+
+interface CardProps {
+  title: string;
+  buttonText: string;
+}
+
+const Card = ({ title, buttonText }: CardProps) => {
+  return (
+    <div className="flex">
+      <div className="block rounded-lg shadow-lg bg-white">
+        <div className="my-32 mx-24 text-center">
+          <h2 className="text-gray-900 text-xl font-medium mb-8">{title}</h2>
+          <Button text={buttonText} color="purple" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Card;


### PR DESCRIPTION
Re-usable card component. Still getting to grips with tailwind so might need refactoring when we have more items inside the card but can be re-used in other parts of the site.

<img width="426" alt="Screenshot 2022-05-03 at 19 10 49" src="https://user-images.githubusercontent.com/68962562/166516073-0ee8aec4-275d-47c5-9c39-2a6ed6881ffd.png">
