### PR TITLE
feat: add landing page layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,12 @@
 import React from "react";
-import Hero from "./components/Hero";
-import Navbar from "./components/Navbar"
-import PlanNewTrip from "./components/PlanNewTrip"
+import LandingPage from "./views/LandingPage";
+import Navbar from "./components/Navbar";
 
 function App() {
   return (
     <div>
       <Navbar />
-      <Hero />
-      <PlanNewTrip />
+      <LandingPage />
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@ body {
 
 /* #region global styles */
 .card {
-  @apply bg-white rounded-3xl flex flex-col items-center drop-shadow-xl mx-auto my-20 overflow-hidden h-80;
+  @apply bg-white rounded-3xl flex flex-col items-center drop-shadow-xl mx-auto overflow-hidden h-80;
 }
 
 .tab-wrapper {
@@ -115,3 +115,13 @@ header {
 	@apply bg-white text-red-600 border-red-600 border-2 border-solid hover:text-white hover:bg-red-600;
 }
 /* #end component button */
+
+/* #region landing page */
+.landing-page {
+  @apply h-full
+}
+
+.landing-page .card-grid {
+  @apply grid grid-cols-2 gap-x-16 mx-auto w-fit pt-16;
+}
+/* #endregion landing page */

--- a/src/views/LandingPage.tsx
+++ b/src/views/LandingPage.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Hero from "../components/Hero";
+import PlanNewTrip from "../components/PlanNewTrip";
+
+function LandingPage() {
+  // replace second PlanNewTrip card with the Log In/Sign Up card when ready
+  return (
+    <div className="landing-page">
+      <Hero />
+      <div className="card-grid">
+        <PlanNewTrip />
+        <PlanNewTrip />
+      </div>
+    </div>
+  );
+}
+
+export default LandingPage;


### PR DESCRIPTION
Added the landing page component (that will hold all its sub components). It will eventually be handled by routing, but for now is the only page. 

The second "PlanNewTrip" card will eventually be replaced, but it's just a placeholder for now.

![image](https://user-images.githubusercontent.com/74154911/166584126-20d0b86f-5e1e-4a9c-8e28-31870cb8910b.png)
